### PR TITLE
fix: pass both bounds to CE scans so `between` works

### DIFF
--- a/AI_Context/MCP_Bridge_Command_Reference.md
+++ b/AI_Context/MCP_Bridge_Command_Reference.md
@@ -490,9 +490,17 @@
 **Purpose:** Perform a value-based memory scan (like CE's memory scanner).
 
 **Parameters:**
-- `value` (str, required): Value to search for.
+- `value` (str, optional): Value to search for. Omit when `scan_option` is `"unknown"`.
 - `type` (str, default=`"dword"`): Value type — `"byte"`, `"word"`, `"dword"`, `"qword"`, `"float"`, `"double"`, `"string"`.
 - `protection` (str, default=`"+W-C"`): Memory protection filter. `+W-C` = writable, not copy-on-write.
+- `scan_option` (str, default=`"exact"`): One of `"exact"`, `"unknown"`, `"between"`, `"bigger"`, `"smaller"`.
+- `value2` (str, optional): Upper bound for `"between"`. See **Between scans** below.
+
+**Between scans:** CE's `firstScan`/`nextScan` take two inputs, and `between`
+needs both. Pass the bounds either as `value="0"` + `value2="1"`, or packed into
+`value` as `"min,max"` / `"min..max"` (e.g. `"0,1"`). A single unpacked value is
+rejected with `INVALID_PARAMS` rather than silently scanning for nothing.
+`-` is not accepted as a separator because it collides with negative numbers.
 
 **Returns:** JSON with:
 - `success` (bool)
@@ -501,6 +509,11 @@
 **Example request:**
 ```json
 {"method": "scan_all", "params": {"value": "100", "type": "dword"}}
+```
+
+**Example request (between):**
+```json
+{"method": "scan_all", "params": {"value": "0", "value2": "1", "type": "dword", "scan_option": "between"}}
 ```
 
 **Example response:**
@@ -544,8 +557,9 @@
 **Purpose:** Filter results from a previous scan, narrowing down candidates.
 
 **Parameters:**
-- `value` (str, optional): New value to scan for. Required when `scan_type` is `"exact"`, `"bigger"`, or `"smaller"`; omit for `"increased"`, `"decreased"`, `"changed"`, `"unchanged"`.
-- `scan_type` (str, default=`"exact"`): One of `"exact"`, `"increased"`, `"decreased"`, `"changed"`, `"unchanged"`, `"bigger"`, `"smaller"`.
+- `value` (str, optional): New value to scan for. Required when `scan_type` is `"exact"`, `"between"`, `"bigger"`, `"smaller"`, `"increased_by"`, or `"decreased_by"`; omit for `"increased"`, `"decreased"`, `"changed"`, `"unchanged"`.
+- `scan_type` (str, default=`"exact"`): One of `"exact"`, `"between"`, `"bigger"`, `"smaller"`, `"increased"`, `"decreased"`, `"increased_by"`, `"decreased_by"`, `"changed"`, `"unchanged"`. Also accepted as `scan_option`.
+- `value2` (str, optional): Upper bound for `"between"` (see **Between scans** under `scan_all`).
 
 **Returns:** JSON with:
 - `success` (bool)
@@ -2180,12 +2194,12 @@
 **Purpose:** Create a persistent scan session that survives multiple next-scans.
 
 **Parameters:**
-- `value_type` (str, required): Value type to scan for (e.g., `"4Bytes"`, `"Float"`).
-- `protection` (str, default=`"+W-C"`): Memory protection filter.
+- `name` (str, required): Caller-chosen identifier for the session. Re-using an
+  existing name destroys the old session first.
 
 **Returns:** JSON with:
 - `success` (bool)
-- `scan_id` (str): Identifier for this persistent scan session.
+- `scan_name` (str): Identifier for this persistent scan session.
 
 ---
 
@@ -2194,14 +2208,21 @@
 **Purpose:** Perform the initial scan in a persistent scan session.
 
 **Parameters:**
-- `scan_id` (str, required): Persistent scan session ID.
-- `value` (str, required): Value to scan for.
-- `scan_type` (str, default=`"exact"`): Scan type.
+- `name` (str, required): Persistent scan session name.
+- `value` (str, optional): Value to scan for. Omit when `scan_option` is `"unknown"`.
+- `type` (str, default=`"dword"`): Value type — `"byte"`, `"word"`, `"dword"`, `"qword"`, `"float"`, `"double"`, `"string"`.
+- `scan_option` (str, default=`"exact"`): One of `"exact"`, `"unknown"`, `"between"`, `"bigger"`, `"smaller"`.
+- `value2` (str, optional): Upper bound for `"between"` (see **Between scans** under `scan_all`).
 
 **Returns:** JSON with:
 - `success` (bool)
-- `scan_id` (str)
+- `scan_name` (str)
 - `count` (int): Initial result count.
+
+**Example request (between):**
+```json
+{"method": "persistent_scan_first_scan", "params": {"name": "hp", "type": "dword", "scan_option": "between", "value": "0", "value2": "1"}}
+```
 
 ---
 
@@ -2210,13 +2231,14 @@
 **Purpose:** Perform a follow-up scan in a persistent scan session.
 
 **Parameters:**
-- `scan_id` (str, required): Persistent scan session ID.
-- `value` (str, optional): New value (required for exact/bigger/smaller).
-- `scan_type` (str, default=`"exact"`): Scan type.
+- `name` (str, required): Persistent scan session name.
+- `value` (str, optional): New value. Required for `"exact"`, `"between"`, `"bigger"`, `"smaller"`, `"increased_by"`, `"decreased_by"`.
+- `scan_option` (str, default=`"exact"`): One of `"exact"`, `"between"`, `"bigger"`, `"smaller"`, `"increased"`, `"decreased"`, `"increased_by"`, `"decreased_by"`, `"changed"`, `"unchanged"`.
+- `value2` (str, optional): Upper bound for `"between"`.
 
 **Returns:** JSON with:
 - `success` (bool)
-- `scan_id` (str)
+- `scan_name` (str)
 - `count` (int): Remaining result count.
 
 ---
@@ -2226,15 +2248,16 @@
 **Purpose:** Retrieve results from a persistent scan session.
 
 **Parameters:**
-- `scan_id` (str, required): Persistent scan session ID.
+- `name` (str, required): Persistent scan session name.
 - `offset` (int, default=0): Result offset for pagination.
 - `limit` (int, default=100): Maximum results to return.
 
 **Returns:** JSON with:
 - `success` (bool)
-- `scan_id` (str)
-- `count` (int): Total result count.
-- `addresses` (array): Hex address strings for this page.
+- `scan_name` (str)
+- `total` (int): Total result count.
+- `offset` (int), `limit` (int)
+- `results` (array): List of `{address, value}` for this page.
 
 ---
 
@@ -2243,11 +2266,12 @@
 **Purpose:** Destroy a persistent scan session and free its resources.
 
 **Parameters:**
-- `scan_id` (str, required): Persistent scan session ID.
+- `name` (str, required): Persistent scan session name.
 
 **Returns:** JSON with:
 - `success` (bool)
-- `scan_id` (str)
+- `scan_name` (str)
+- `destroyed` (bool)
 
 ---
 
@@ -3161,9 +3185,9 @@ Several tools that return potentially large result sets support pagination via `
 offset = 0
 page_size = 100
 while True:
-    result = persistent_scan_get_results(scan_id="...", offset=offset, limit=page_size)
-    process(result["addresses"])
-    if len(result["addresses"]) < page_size:
+    result = persistent_scan_get_results(name="...", offset=offset, limit=page_size)
+    process(result["results"])
+    if len(result["results"]) < page_size:
         break
     offset += page_size
 ```
@@ -3298,13 +3322,13 @@ All commands return `success: false` with an `error` field on failure:
 ### Example 4: Persistent Multi-Step Scan
 
 ```
-1. create_persistent_scan(value_type="4Bytes") → scan_id="scan_1"
-2. persistent_scan_first_scan(scan_id="scan_1", value="100")  → count: 50000
+1. create_persistent_scan(name="gold") → scan_name="gold"
+2. persistent_scan_first_scan(name="gold", type="dword", value="100")  → count: 50000
 3. [Spend gold in game]
-4. persistent_scan_next_scan(scan_id="scan_1", scan_type="decreased") → count: 500
-5. persistent_scan_next_scan(scan_id="scan_1", value="75") → count: 3
-6. persistent_scan_get_results(scan_id="scan_1") → ["0x12345678", ...]
-7. persistent_scan_destroy(scan_id="scan_1")
+4. persistent_scan_next_scan(name="gold", scan_option="decreased") → count: 500
+5. persistent_scan_next_scan(name="gold", value="75") → count: 3
+6. persistent_scan_get_results(name="gold") → [{"address": "0x12345678", ...}]
+7. persistent_scan_destroy(name="gold")
 ```
 
 ---

--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -131,6 +131,61 @@ local function paginate(params, items, defaultLimit)
     return limit, offset, page, total
 end
 
+-- Map a human-readable scan_option to a CE scan constant.
+-- Returns nil for unrecognized options so callers can report INVALID_PARAMS instead of silently falling back to an exact scan.
+-- Global (not local) so handlers defined earlier in the chunk can call it and so it doesn't consume one of Lua's 200 local slots.
+function resolveScanOption(opt)
+    local o = tostring(opt or "exact"):lower()
+    if o == "exact"             then return soExactValue
+    elseif o == "unknown"       then return soUnknownValue
+    elseif o == "between"       then return soValueBetween
+    elseif o == "bigger"        then return soBiggerThan
+    elseif o == "smaller"       then return soSmallerThan
+    elseif o == "increased"     then return soIncreasedValue
+    elseif o == "increased_by"  then return soIncreasedValueBy
+    elseif o == "decreased"     then return soDecreasedValue
+    elseif o == "decreased_by"  then return soDecreasedValueBy
+    elseif o == "changed"       then return soChanged
+    elseif o == "unchanged"     then return soUnchanged
+    else return nil
+    end
+end
+
+SCAN_OPTION_NAMES = "exact, unknown, between, bigger, smaller, increased, increased_by, decreased, decreased_by, changed, unchanged"
+
+-- CE's firstScan/nextScan take two inputs; soValueBetween (and the *_by options) need BOTH of them.
+-- Passing the bounds as a single "0,1" string with input2 = nil makes CE scan for garbage and return 0 hits.
+-- Returns: input1, input2, errorMessage
+--   "between" accepts either an explicit value2, or a single value holding both bounds separated by "," or ".." (e.g. "0,1" / "0..1").
+--   "-" is deliberately not a separator because it collides with negative numbers.
+function resolveScanInputs(scanOpt, value, value2)
+    -- Options that compare against the previous scan take no input at all.
+    if scanOpt == soUnknownValue or scanOpt == soChanged or scanOpt == soUnchanged
+       or scanOpt == soIncreasedValue or scanOpt == soDecreasedValue then
+        return nil, nil, nil
+    end
+
+    if scanOpt == soValueBetween then
+        local lo, hi
+        if value2 ~= nil and tostring(value2) ~= "" then
+            lo, hi = value, value2
+        else
+            local s = tostring(value or "")
+            lo, hi = s:match("^%s*(.-)%s*,%s*(.-)%s*$")
+            if not lo then lo, hi = s:match("^%s*(.-)%s*%.%.%s*(.-)%s*$") end
+        end
+        if lo == nil or hi == nil or tostring(lo) == "" or tostring(hi) == "" then
+            return nil, nil, "'between' needs two bounds: pass value2, or value as \"min,max\" (e.g. \"0,1\")"
+        end
+        return tostring(lo), tostring(hi), nil
+    end
+
+    if value == nil or tostring(value) == "" then
+        return nil, nil, "This scan option requires a value"
+    end
+    return tostring(value), nil, nil
+end
+
 -- ============================================================================
 -- SHARED HELPERS (Unit 5 refactor — used by multiple cmd_* handlers)
 -- ============================================================================
@@ -853,24 +908,37 @@ end
 function cmd_scan_all(params)
     local value = params.value
     local vtype = params.type or "dword"
-    
-    local ms = createMemScan()
-    local scanOpt = soExactValue
+
+    local scanOpt = resolveScanOption(params.scan_option or "exact")
+    if not scanOpt then
+        return { success = false, error = "Unknown scan_option '" .. tostring(params.scan_option) .. "'. Valid: " .. SCAN_OPTION_NAMES, error_code = "INVALID_PARAMS" }
+    end
+    if scanOpt ~= soExactValue and scanOpt ~= soUnknownValue and scanOpt ~= soValueBetween
+       and scanOpt ~= soBiggerThan and scanOpt ~= soSmallerThan then
+        return { success = false, error = "scan_option '" .. tostring(params.scan_option) .. "' is only valid for next_scan. First scan supports: exact, unknown, between, bigger, smaller", error_code = "INVALID_PARAMS" }
+    end
+
+    local input1, input2, inputErr = resolveScanInputs(scanOpt, value, params.value2)
+    if inputErr then
+        return { success = false, error = inputErr, error_code = "INVALID_PARAMS" }
+    end
+
     local varType = vtDword
-    
     if vtype == "byte" then varType = vtByte
     elseif vtype == "word" then varType = vtWord
     elseif vtype == "qword" then varType = vtQword
     elseif vtype == "float" then varType = vtSingle
     elseif vtype == "double" then varType = vtDouble
     elseif vtype == "string" then varType = vtString end
-    
+
+    local ms = createMemScan()
+
     -- Use specific protection flags if provided (defaults to +W-C from Python)
     -- CRITICAL: Limit scan to User Mode space (0x7FFFFFFFFFFFFFFF) to prevent BSODs in Kernel/Guard regions
     local protect = params.protection or "+W-C"
-    ms.firstScan(scanOpt, varType, rtRounded, tostring(value), nil, 0, 0x7FFFFFFFFFFFFFFF, protect, fsmNotAligned, "1", false, false, false, false)
+    ms.firstScan(scanOpt, varType, rtRounded, input1, input2, 0, 0x7FFFFFFFFFFFFFFF, protect, fsmNotAligned, "1", false, false, false, false)
     ms.waitTillDone()
-    
+
     local fl = createFoundList(ms)
     fl.initialize()
     local count = fl.getCount()
@@ -926,30 +994,30 @@ end
 
 function cmd_next_scan(params)
     local value = params.value
-    local scanType = params.scan_type or "exact"
-    
+    -- scan_option is the v12 name; scan_type is kept as a backward-compat alias
+    local scanType = params.scan_option or params.scan_type or "exact"
+
     if not serverState.scan_memscan then
         return { success = false, error = "No previous scan. Run scan_all first." }
     end
-    
+
     local ms = serverState.scan_memscan
-    local scanOpt = soExactValue
-    
-    if scanType == "increased" then scanOpt = soIncreasedValue
-    elseif scanType == "decreased" then scanOpt = soDecreasedValue
-    elseif scanType == "changed" then scanOpt = soChanged
-    elseif scanType == "unchanged" then scanOpt = soUnchanged
-    elseif scanType == "bigger" then scanOpt = soBiggerThan
-    elseif scanType == "smaller" then scanOpt = soSmallerThan
+    local scanOpt = resolveScanOption(scanType)
+    if not scanOpt then
+        return { success = false, error = "Unknown scan_option '" .. tostring(scanType) .. "'. Valid: " .. SCAN_OPTION_NAMES, error_code = "INVALID_PARAMS" }
     end
-    
-    if scanOpt == soExactValue then
-        ms.nextScan(scanOpt, rtRounded, tostring(value), nil, false, false, false, false, false)
-    else
-        ms.nextScan(scanOpt, rtRounded, nil, nil, false, false, false, false, false)
+    if scanOpt == soUnknownValue then
+        return { success = false, error = "scan_option 'unknown' is only valid for scan_all", error_code = "INVALID_PARAMS" }
     end
+
+    local input1, input2, inputErr = resolveScanInputs(scanOpt, value, params.value2)
+    if inputErr then
+        return { success = false, error = inputErr, error_code = "INVALID_PARAMS" }
+    end
+
+    ms.nextScan(scanOpt, rtRounded, input1, input2, false, false, false, false, false)
     ms.waitTillDone()
-    
+
     if serverState.scan_foundlist then
         serverState.scan_foundlist.destroy()
     end
@@ -3570,21 +3638,7 @@ local function resolveVarType(vtype)
     end
 end
 
--- Helper: map human-readable scan_option to CE constant
-local function resolveScanOption(opt)
-    local o = (opt or "exact"):lower()
-    if o == "exact"          then return soExactValue
-    elseif o == "unknown"    then return soUnknownValue
-    elseif o == "between"    then return soValueBetween
-    elseif o == "bigger"     then return soBiggerThan
-    elseif o == "smaller"    then return soSmallerThan
-    elseif o == "increased"  then return soIncreasedValue
-    elseif o == "decreased"  then return soDecreasedValue
-    elseif o == "changed"    then return soChanged
-    elseif o == "unchanged"  then return soUnchanged
-    else return soExactValue
-    end
-end
+-- resolveScanOption / resolveScanInputs live in the HELPER FUNCTIONS section at the top of this file (global, so every cmd_* handler shares one mapping).
 
 function cmd_aob_scan_unique(params)
     local ok, err = requireProcess()
@@ -3775,20 +3829,31 @@ function cmd_persistent_scan_first_scan(params)
     local vtype       = params.type or "dword"
     local scan_option = params.scan_option or "exact"
 
-    if not name  then return { success = false, error = "No name provided",  error_code = "INVALID_PARAMS" } end
-    if not value then return { success = false, error = "No value provided", error_code = "INVALID_PARAMS" } end
+    if not name then return { success = false, error = "No name provided", error_code = "INVALID_PARAMS" } end
 
     local entry = serverState.persistent_scans[name]
     if not entry then
         return { success = false, error = "Scan '" .. name .. "' not found. Call create_persistent_scan first.", error_code = "INVALID_PARAMS" }
     end
 
-    local ms        = entry.ms
-    local varType   = resolveVarType(vtype)
-    local scanOpt   = resolveScanOption(scan_option)
+    local ms      = entry.ms
+    local varType = resolveVarType(vtype)
+    local scanOpt = resolveScanOption(scan_option)
+    if not scanOpt then
+        return { success = false, error = "Unknown scan_option '" .. tostring(scan_option) .. "'. Valid: " .. SCAN_OPTION_NAMES, error_code = "INVALID_PARAMS" }
+    end
+    if scanOpt ~= soExactValue and scanOpt ~= soUnknownValue and scanOpt ~= soValueBetween
+       and scanOpt ~= soBiggerThan and scanOpt ~= soSmallerThan then
+        return { success = false, error = "scan_option '" .. tostring(scan_option) .. "' is only valid for next_scan. First scan supports: exact, unknown, between, bigger, smaller", error_code = "INVALID_PARAMS" }
+    end
+
+    local input1, input2, inputErr = resolveScanInputs(scanOpt, value, params.value2)
+    if inputErr then
+        return { success = false, error = inputErr, error_code = "INVALID_PARAMS" }
+    end
 
     local fsOk, fsMsg = pcall(function()
-        ms.firstScan(scanOpt, varType, rtRounded, tostring(value), nil,
+        ms.firstScan(scanOpt, varType, rtRounded, input1, input2,
                      0, 0x7FFFFFFFFFFFFFFF, "+W-C", fsmNotAligned, "1",
                      false, false, false, false)
         ms.waitTillDone()
@@ -3833,13 +3898,20 @@ function cmd_persistent_scan_next_scan(params)
 
     local ms      = entry.ms
     local scanOpt = resolveScanOption(scan_option)
+    if not scanOpt then
+        return { success = false, error = "Unknown scan_option '" .. tostring(scan_option) .. "'. Valid: " .. SCAN_OPTION_NAMES, error_code = "INVALID_PARAMS" }
+    end
+    if scanOpt == soUnknownValue then
+        return { success = false, error = "scan_option 'unknown' is only valid for first_scan", error_code = "INVALID_PARAMS" }
+    end
+
+    local input1, input2, inputErr = resolveScanInputs(scanOpt, value, params.value2)
+    if inputErr then
+        return { success = false, error = inputErr, error_code = "INVALID_PARAMS" }
+    end
 
     local nsOk, nsMsg = pcall(function()
-        if scanOpt == soExactValue or scanOpt == soValueBetween or scanOpt == soBiggerThan or scanOpt == soSmallerThan then
-            ms.nextScan(scanOpt, rtRounded, tostring(value or ""), nil, false, false, false, false, false)
-        else
-            ms.nextScan(scanOpt, rtRounded, nil, nil, false, false, false, false, false)
-        end
+        ms.nextScan(scanOpt, rtRounded, input1, input2, false, false, false, false, false)
         ms.waitTillDone()
     end)
     if not nsOk then

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -578,9 +578,22 @@ def checksum_memory(address: str, size: int) -> str:
 # --- SCANNING ---
 
 @mcp.tool()
-def scan_all(value: str, type: str = "exact", protection: str = "+W-C") -> str:
-    """Unified Memory Scanner. Types: exact, string, array. Protection: +W-C (Writable, Not Copy-on-Write)."""
-    return format_result(ce_client.send_command("scan_all", {"value": value, "type": type, "protection": protection}))
+def scan_all(value: str = None, type: str = "dword", protection: str = "+W-C",
+             scan_option: str = "exact", value2: str = None) -> str:
+    """Unified Memory Scanner (first scan).
+
+    Args:
+        value: Value to search for. Omit when scan_option is 'unknown'.
+        type: Value type: byte, word, dword, qword, float, double, string.
+        protection: +W-C (Writable, Not Copy-on-Write).
+        scan_option: exact, unknown, between, bigger, smaller.
+        value2: Upper bound for 'between'.
+            Alternatively pass both bounds in value as "min,max" (e.g. "0,1").
+    """
+    return format_result(ce_client.send_command("scan_all", {
+        "value": value, "type": type, "protection": protection,
+        "scan_option": scan_option, "value2": value2
+    }))
 
 @mcp.tool()
 def get_scan_results(offset: int = 0, limit: int = 100, max: int = None) -> str:
@@ -596,9 +609,17 @@ def get_scan_results(offset: int = 0, limit: int = 100, max: int = None) -> str:
     return format_result(ce_client.send_command("get_scan_results", {"offset": offset, "limit": limit, "max": max}))
 
 @mcp.tool()
-def next_scan(value: str, scan_type: str = "exact") -> str:
-    """Next scan to filter results. Types: exact, increased, decreased, changed, unchanged, bigger, smaller."""
-    return format_result(ce_client.send_command("next_scan", {"value": value, "scan_type": scan_type}))
+def next_scan(value: str = None, scan_type: str = "exact", value2: str = None) -> str:
+    """Next scan to filter results from the last 'scan_all'.
+
+    Args:
+        value: Value to compare against. Not needed for increased/decreased/changed/unchanged.
+        scan_type: exact, between, bigger, smaller, increased, decreased, increased_by, decreased_by, changed, unchanged.
+        value2: Upper bound for 'between'. Alternatively pass both bounds in value as "min,max" (e.g. "0,1").
+    """
+    return format_result(ce_client.send_command("next_scan", {
+        "value": value, "scan_type": scan_type, "value2": value2
+    }))
 
 @mcp.tool()
 def write_integer(address: str, value: int, type: str = "dword") -> str:
@@ -1626,26 +1647,31 @@ def create_persistent_scan(name: str) -> str:
     return format_result(ce_client.send_command("create_persistent_scan", {"name": name}))
 
 @mcp.tool()
-def persistent_scan_first_scan(name: str, value: str, type: str = "dword", scan_option: str = "exact") -> str:
+def persistent_scan_first_scan(name: str, value: str = None, type: str = "dword", scan_option: str = "exact", value2: str = None) -> str:
     """Run the first scan on a named persistent scan session.
     Types: byte, word, dword, qword, float, double, string.
     Scan options: exact, unknown, between, bigger, smaller.
+    'between' needs two bounds: pass value2, or put both in value as "min,max" (e.g. value="0,1").
+    'unknown' takes no value.
     Returns {success, scan_name, count}."""
-    return format_result(ce_client.send_command("persistent_scan_first_scan", {
-        "name": name,
-        "value": value,
-        "type": type,
-        "scan_option": scan_option
-    }))
+    params = {"name": name, "type": type, "scan_option": scan_option}
+    if value is not None:
+        params["value"] = value
+    if value2 is not None:
+        params["value2"] = value2
+    return format_result(ce_client.send_command("persistent_scan_first_scan", params))
 
 @mcp.tool()
-def persistent_scan_next_scan(name: str, value: str = None, scan_option: str = "exact") -> str:
+def persistent_scan_next_scan(name: str, value: str = None, scan_option: str = "exact", value2: str = None) -> str:
     """Narrow down results with a next scan on a named persistent scan session.
-    Scan options: exact, increased, decreased, changed, unchanged, bigger, smaller.
+    Scan options: exact, between, bigger, smaller, increased, decreased, increased_by, decreased_by, changed, unchanged.
+    'between' needs two bounds: pass value2, or put both in value as "min,max".
     Returns {success, scan_name, count}."""
     params = {"name": name, "scan_option": scan_option}
     if value is not None:
         params["value"] = value
+    if value2 is not None:
+        params["value2"] = value2
     return format_result(ce_client.send_command("persistent_scan_next_scan", params))
 
 @mcp.tool()

--- a/MCP_Server/test_mcp.py
+++ b/MCP_Server/test_mcp.py
@@ -1127,7 +1127,7 @@ def main():
         # First do a scan_all with a common dword value (1) so we have a baseline.
         all_tests["u24_scan_for_nextscan"] = TestCase(
             "Unit-24 scan_all baseline (value=1, dword)", "scan_all",
-            params={"value": "1", "type": "exact"},
+            params={"value": "1", "type": "dword"},
             validators=[
                 has_field("success", bool),
                 field_equals("success", True),
@@ -1171,6 +1171,36 @@ def main():
             skip_reason=_ns_filter_skip,
         )
         all_tests["u24_next_scan_changed"].run(client)
+
+        # Regression: 'between' used to pass both bounds as one string with input2=nil, so CE scanned for garbage and every between scan returned 0.
+        # A dword between 0 and 1 must match something in any live process.
+        all_tests["u24_scan_between_packed"] = TestCase(
+            "Unit-24 scan_all between via packed \"0,1\"", "scan_all",
+            params={"value": "0,1", "type": "dword", "scan_option": "between"},
+            validators=[
+                field_equals("success", True),
+                has_field("count", int),
+                lambda r: (r.get("count", 0) > 0,
+                           f"between 0,1 returned {r.get('count')} results (expected > 0)"),
+            ],
+            skip_reason=_nextscan_skip,
+        )
+        all_tests["u24_scan_between_packed"].run(client)
+
+        all_tests["u24_scan_between_value2"] = TestCase(
+            "Unit-24 scan_all between via value/value2", "scan_all",
+            params={"value": "0", "value2": "1", "type": "dword", "scan_option": "between"},
+            validators=[
+                field_equals("success", True),
+                has_field("count", int),
+                lambda r: (r.get("count", 0) > 0,
+                           f"between 0..1 returned {r.get('count')} results (expected > 0)"),
+            ],
+            skip_reason=_nextscan_skip,
+        )
+        all_tests["u24_scan_between_value2"].run(client)
+
+        # (The rejection cases for 'between' live in the Error Cases section below.)
 
         # -------------------------------------------------------------------------
         # Breakpoint lifecycle — execution breakpoint
@@ -1450,6 +1480,23 @@ def main():
         )
         all_tests["u24_err_invalid_addr"].run(client)
 
+        # A 'between' scan given only one bound must be rejected rather than silently scanning for garbage (the old behaviour returned count=0).
+        all_tests["u24_err_between_one_bound"] = _ErrorCase(
+            "Unit-24 Error: scan_all between with a single bound",
+            "scan_all",
+            params={"value": "0", "type": "dword", "scan_option": "between"},
+            validators=[_expect_error(error_code="INVALID_PARAMS")],
+        )
+        all_tests["u24_err_between_one_bound"].run(client)
+
+        all_tests["u24_err_bad_scan_option"] = _ErrorCase(
+            "Unit-24 Error: scan_all with an unknown scan_option",
+            "scan_all",
+            params={"value": "1", "type": "dword", "scan_option": "definitely_not_an_option"},
+            validators=[_expect_error(error_code="INVALID_PARAMS")],
+        )
+        all_tests["u24_err_bad_scan_option"].run(client)
+
         all_tests["u24_err_null_read"] = _ErrorCase(
             "Unit-24 Error: read_memory at 0x0 (expect error)",
             "read_memory",
@@ -1621,6 +1668,7 @@ def main():
     ]
     _u24_scan_keys = [
         "u24_scan_for_nextscan", "u24_next_scan_unchanged", "u24_next_scan_changed",
+        "u24_scan_between_packed", "u24_scan_between_value2",
     ]
     _u24_bp_keys = [
         "u24_set_breakpoint", "u24_get_bp_hits", "u24_remove_breakpoint",
@@ -1628,7 +1676,10 @@ def main():
         "u24_set_data_breakpoint", "u24_get_data_bp_hits", "u24_remove_data_breakpoint",
     ]
     _u24_page_keys = ["u24_page1", "u24_page2", "u24_pages_distinct"]
-    _u24_err_keys = ["u24_err_invalid_addr", "u24_err_null_read"]
+    _u24_err_keys = [
+        "u24_err_invalid_addr", "u24_err_null_read",
+        "u24_err_between_one_bound", "u24_err_bad_scan_option",
+    ]
     _u24_smoke_keys = [
         "u24_smoke_get_process_list", "u24_smoke_allocate_memory", "u24_smoke_free_memory",
         "u24_smoke_execute_code_local", "u24_smoke_enum_registered_symbols",


### PR DESCRIPTION
## Problem

CE's `firstScan`/`nextScan` take two value inputs — for `soValueBetween`, `input1` is the lower bound and `input2` the upper. Every scan handler hardcoded `input2 = nil` and packed the whole value into `input1`, so a `between` scan matched nothing. Two more bugs in the same family:

- `next_scan` with `bigger`/`smaller` passed `input1 = nil`, silently scanning for nothing.
- `next_scan` had no `between` option at all.

On top of that, every scan-option map ended in `else return soExactValue`, so a typo'd option silently ran an exact scan instead of failing.

## Fix

- New shared helpers `resolveScanOption` / `resolveScanInputs` used by `scan_all`, `next_scan`, and both `persistent_scan` handlers, so the four paths cannot drift again.
- `between` passes both bounds; a `between` missing a bound and any unknown option now return `INVALID_PARAMS`.
- Added the `increased_by` / `decreased_by` options CE supports but the bridge never exposed.

## Docs & tests

- Command reference: the `persistent_scan` tools were documented with `scan_id`/`scan_type`/`value_type` params that don't exist (they are `name`/`scan_option`/`type`); the pagination example used the same phantom names. Both corrected.
- `scan_all`'s Python docstring advertised types "exact, string, array" instead of the `byte`/`word`/`dword`/… the Lua actually expects.
- New `test_mcp.py` cases: `between` via packed value and via `value2`, plus error cases for a one-bound `between` and an unknown scan option.

## Verification

Against live CE: a dword scan `between` 0 and 1 returned 0 hits before this change and 86,408,395 after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
