### PR TITLE
Pin mcp to <2.0. fastmcp removed in 2.0

### DIFF
--- a/MCP_Server/requirements-tcp.txt
+++ b/MCP_Server/requirements-tcp.txt
@@ -3,4 +3,4 @@
 #   python3 -m pip install -r MCP_Server/requirements-tcp.txt
 
 # MCP SDK (Model Context Protocol) - Required for AI agent communication
-mcp>=1.0.0
+mcp>=1.28,<2  # v2.0.0 removed mcp.server.fastmcp; pin until code is migrated to the v2 API

--- a/MCP_Server/requirements.txt
+++ b/MCP_Server/requirements.txt
@@ -2,7 +2,7 @@
 # Install: pip install -r requirements.txt
 
 # MCP SDK (Model Context Protocol) - Required for AI agent communication
-mcp>=1.0.0
+mcp>=1.28,<2  # v2.0.0 removed mcp.server.fastmcp; pin until code is migrated to the v2 API
 
 # Windows API bindings - Required for Named Pipe communication
 pywin32>=306


### PR DESCRIPTION
Updated both requirements.txt to set upper bounding on mcp version to 2.0. fastMCP was removed in mcp 2.0 which resulted in import failures during MCP client init.